### PR TITLE
Add happy/sad path tests for deleting projects+its palettes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # dependencies
 /node_modules
 
+# test coverage
+/coverage
+
 # misc
 .DS_Store

--- a/app.js
+++ b/app.js
@@ -178,4 +178,22 @@ app.patch('/api/v1/palettes/:id', async (req, res) => {
   };
 });
 
+app.delete('/api/v1/projects/:id', async (req, res) => {
+  let { id } = req.params;
+  let foundProject = await database('projects').where('id', id).select();
+  id = parseInt(id);
+  if (!id || !foundProject.length) {
+    return res.status(404).send({
+      error: `No project with id: ${id} exists. It has either already been deleted or the id sent with request is incorrect.`
+    });
+  }
+  try {
+    await database('palettes').where('project_id', id).del();
+    await database('projects').where('id', id).del();
+    res.status(200).send({ id: id });
+  } catch (error) {
+    res.status(500).json({ error });
+  }
+});
+
 export default app;

--- a/app.js
+++ b/app.js
@@ -196,4 +196,27 @@ app.delete('/api/v1/projects/:id', async (req, res) => {
   }
 });
 
+app.delete('/api/v1/palettes/:id', async (req, res) => {
+  let {
+    id
+  } = req.params;
+  let foundPalette = await database('palettes').where('id', id).select();
+  id = parseInt(id);
+  if (!id || !foundPalette.length) {
+    return res.status(404).send({
+      error: `No palette with id: ${id} exists. It has either already been deleted or the id sent with request is incorrect.`
+    });
+  }
+  try {
+    await database('palettes').where('id', id).del();
+    res.status(200).send({
+      id: id
+    });
+  } catch (error) {
+    res.status(500).json({
+      error
+    });
+  }
+});
+
 export default app;

--- a/app.test.js
+++ b/app.test.js
@@ -222,4 +222,25 @@ describe('Server', () => {
       expect(res.body.error).toBe('Palette with that name already exists under that project id');
     });
   });
+
+  describe('DELETE /api/v1/projects/:id', () => {
+    it('should return 200 and the id of the deleted resource', async () => {
+      const project = await database('projects').first();
+      const res = await request(app).delete(`/api/v1/projects/${project.id}`);
+      const palettesInProject = await database('palettes').where('project_id', project.id).select();
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ id: project.id });
+      expect(palettesInProject.length).toBe(0);
+    });
+
+    it('should return 404 if project id is not found or missing', async () => {
+      const invalidId = -1
+      const res = await request(app).delete(`/api/v1/projects/${invalidId}`);
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No project with id: -1 exists. It has either already been deleted or the id sent with request is incorrect.');
+      const res2 = await request(app).delete(`/api/v1/projects/`);
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No project with id: -1 exists. It has either already been deleted or the id sent with request is incorrect.');
+    });
+  });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -243,4 +243,27 @@ describe('Server', () => {
       expect(res.body.error).toBe('No project with id: -1 exists. It has either already been deleted or the id sent with request is incorrect.');
     });
   });
+
+  describe('DELETE /api/v1/palettes/:id', () => {
+    it('should return 200 and the id of the deleted resource', async () => {
+      const palette = await database('palettes').first();
+      const res = await request(app).delete(`/api/v1/palettes/${palette.id}`);
+      const palettesCheck = await database('palettes').where('id', palette.id).select();
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        id: palette.id
+      });
+      expect(palettesCheck.length).toBe(0);
+    });
+
+    it('should return 404 if palette id is not found or missing', async () => {
+      const invalidId = -1
+      const res = await request(app).delete(`/api/v1/palettes/${invalidId}`);
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No palette with id: -1 exists. It has either already been deleted or the id sent with request is incorrect.');
+      const res2 = await request(app).delete(`/api/v1/palettes/`);
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No palette with id: -1 exists. It has either already been deleted or the id sent with request is incorrect.');
+    });
+  });
 });


### PR DESCRIPTION
#### What's this PR do?
- Add happy path test and endpoint for deleting a project and its associated palettes.
- Add sad path test for missing or invalid id when deleting a project.
- Amend endpoint to include sad path when deleting with a missing or invalid id
- Add happy path test and endpoint for deleting a palette.
- Add sad path test for missing or invalid id when deleting a palette.
- Amend endpoint to include sad path when deleting with a missing or invalid id
#### Where should the reviewer start?
- Testing review
#### How should this be manually tested?
- n/a
#### Any background context you want to provide?
- TravisCI build successful with this branch.
#### Screenshots (if appropriate):
#### Questions:
